### PR TITLE
fix invalid compare links in changelog, document sensu-plugin dep change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [0.0.4] - 2016-06-15
 ### Added
+- Updated sensu-plugin dependency from `= 1.2.0` to `~> 1.2`
 - now support HTTPS with the "-s" toggle
 
 ## [0.0.3] - 2015-07-14
@@ -24,7 +25,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-iis/compare/0.0.4...HEAD
-[0.0.4]: https://github.com/sensu-plugins/sensu-plugins-iis/compare/0.0.3...0.0.4
-[0.0.3]: https://github.com/sensu-plugins/sensu-plugins-iis/compare/0.0.2...0.0.3
-[0.0.2]: https://github.com/sensu-plugins/sensu-plugins-iis/compare/0.0.1...0.0.2
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-uchiwa/compare/0.0.4...HEAD
+[0.0.4]: https://github.com/sensu-plugins/sensu-plugins-uchiwa/compare/0.0.3...0.0.4
+[0.0.3]: https://github.com/sensu-plugins/sensu-plugins-uchiwa/compare/0.0.2...0.0.3
+[0.0.2]: https://github.com/sensu-plugins/sensu-plugins-uchiwa/compare/0.0.1...0.0.2


### PR DESCRIPTION
## Pull Request Checklist

Not related to an existing issue. Fixes invalid changelog compare links, adds documentation for missing change included in 0.0.3->0.0.4 diff.
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [ ] RuboCop passes
- [ ] Existing tests pass 
#### Purpose

Make changelog links usable
#### Known Compatablity Issues

N/A
